### PR TITLE
#2-implemented oncePerRequestFilter to obtain jwt from headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 }
 
 test {

--- a/src/main/java/com/tla/saiyan/config/AccessTokenFilter.java
+++ b/src/main/java/com/tla/saiyan/config/AccessTokenFilter.java
@@ -1,0 +1,41 @@
+package com.tla.saiyan.config;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AccessTokenFilter extends OncePerRequestFilter {
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest,
+                                    HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            var jwt = parseJwt(httpServletRequest.getHeader("Authorization"));
+
+            if (jwt != null) {
+
+                var authentication = new BearerTokenAuthenticationToken(jwt);
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            System.out.println(e.getMessage()); // TODO: replace with logs later.
+        }
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+
+
+    private String parseJwt(String jwtWithBearer) {
+        if (StringUtils.hasText(jwtWithBearer) && jwtWithBearer.startsWith("Bearer "))
+            return jwtWithBearer.substring(7);
+        return null;
+    }
+}

--- a/src/main/java/com/tla/saiyan/config/SecurityConfig.java
+++ b/src/main/java/com/tla/saiyan/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
@@ -38,7 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(new AccessTokenFilter(), UsernamePasswordAuthenticationFilter.class).authorizeRequests()
+                .addFilterBefore(new AccessTokenFilter(), BearerTokenAuthenticationFilter.class).authorizeRequests()
                 .mvcMatchers("/api/public").permitAll()
                 .mvcMatchers("/api/private").authenticated()
                 .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:results")

--- a/src/main/java/com/tla/saiyan/config/SecurityConfig.java
+++ b/src/main/java/com/tla/saiyan/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -36,7 +37,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
+        http
+                .addFilterBefore(new AccessTokenFilter(), UsernamePasswordAuthenticationFilter.class).authorizeRequests()
                 .mvcMatchers("/api/public").permitAll()
                 .mvcMatchers("/api/private").authenticated()
                 .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:results")


### PR DESCRIPTION
- A good start for the OncePerRequestFilter
- Will enhance/improve. For now, the filter:
   i. extracts jwt
  ii. constructs authentication object using BearerTokenAuthenticationToken 
   iii. sets thus obtained authentication object in SecurityContext.